### PR TITLE
PHP 8.1 is not really supported

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,5 +14,5 @@ jobs:
   quality:
     uses: prinsfrank/CI-PHP/.github/workflows/quality.yml@main
     with:
-      PHP_VERSION: '8.3'
+      PHP_VERSION: '8.1'
     secrets: inherit


### PR DESCRIPTION
> symfony/console[v7.0.0, ..., v7.0.6] require php >=8.2